### PR TITLE
added hard conversions for s and ms, fixed empty js library bug

### DIFF
--- a/server/middleware/lighthouse.mjs
+++ b/server/middleware/lighthouse.mjs
@@ -3,7 +3,7 @@ import chromeLauncher from "chrome-launcher";
 
 const lighthouseMiddleware = async (req, res, next) => {
   const { url } = req.query;
-  // lighthouse boilerplate to get data on specified website
+  // lighthouse boilerplate setup to get performance, accessiblity, best practices, and SEO data
   const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
   const options = {
     logLevel: "info",
@@ -11,19 +11,43 @@ const lighthouseMiddleware = async (req, res, next) => {
     onlyCategories: ["performance", "accessibility", "best-practices", "seo"],
     port: chrome.port,
   };
+  // invokes lighthouse passing in naked url with https in front
   const runnerResult = await lighthouse("https://" + url, options);
 
   // `.report` is the HTML report as a string, parsed to JSON object
   let data = JSON.parse(runnerResult.report);
 
-  // metricObject containing relevant metrics for Performance, Accessbility, SEO
+  // function to convert seconds string to milliseconds string
+  function convertToMS(str) {
+    if (str[str.length - 2] !== "m") {
+      let num = Number(str.slice(0, str.indexOf(" ")));
+      return (num * 1000).toString() + " ms";
+    }
+    return str;
+  }
+
+  // function to convert milliseconds string to seconds string
+  function convertToS(str) {
+    if (str[str.length - 2] === "m") {
+      let num = Number(str.slice(0, str.indexOf(" ")));
+      return (num / 1000).toString() + " s";
+    }
+    return str;
+  }
+
+  // metricObject containing relevant metrics in proper format for URL, screenshot image, Performance, Accessbility, SEO, JS Libraries
   let metricObject = {
     url: "https://" + url,
     image: data.audits["final-screenshot"].details.data,
-    firstContentfulPaint: data.audits["first-contentful-paint"].displayValue,
-    totalBlockingTime: data.audits["total-blocking-time"].displayValue,
-    largestContentfulPaint:
-      data.audits["largest-contentful-paint"].displayValue,
+    firstContentfulPaint: convertToS(
+      data.audits["first-contentful-paint"].displayValue
+    ),
+    totalBlockingTime: convertToMS(
+      data.audits["total-blocking-time"].displayValue
+    ),
+    largestContentfulPaint: convertToS(
+      data.audits["largest-contentful-paint"].displayValue
+    ),
     buttonName: data.audits["button-name"].details.items.length,
     imageAlt: data.audits["image-alt"].details.items.length,
     linkName: data.audits["link-name"].details.items.length,
@@ -32,14 +56,13 @@ const lighthouseMiddleware = async (req, res, next) => {
       0,
       data.audits["font-size"].displayValue.indexOf("%") + 1
     ),
-    libraries: data.audits["js-libraries"].details.items.map((el) => el.name),
+    libraries: data.audits["js-libraries"].score
+      ? data.audits["js-libraries"].details.items.map((el) => el.name)
+      : [],
   };
 
-  //console.log(metricObject);
   res.locals.metrics = metricObject;
   return next();
-
-  await chrome.kill();
 };
 
 export default lighthouseMiddleware;


### PR DESCRIPTION
firstContentfulPaint will always be converted to seconds.
totalBlockingTime will always be converted to milliseconds.
largestContentfulPaint will always be convered to seconds.

fixed bug where websites with no detected JS libraries caused runtime to stop. Now returning an empty array for those cases.